### PR TITLE
Introduce releases_keepfiles to keep release files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Ansible Role: releases
-=========
+======================
 
 This role helps with configuring base content for a releases mirror, as well as pre-staging releases into the staging area `.pool` and then actually making the release happen.
 The pre-staging are only ran when specifing the tag `prepare` and the release only happens when specifying the `release` tag.
@@ -18,6 +18,10 @@ Which path on your controller to look for base content in. Could be a relative t
 File pattern for your release files. The default is `custom.*` since that is the default for what the `vcc-caeit.build_iso` role produce.
 
     releases_pattern: custom.*
+
+List of files to keep as visible release symlinks. This could be used if you have valid release files that doesn't match `releases_pattern`.
+
+    releases_keepfiles: []
 
 Ownership of files and directories can be set.
 

--- a/tasks/release.yml
+++ b/tasks/release.yml
@@ -3,7 +3,7 @@
   find:
     paths: "{{ releases_path }}"
     patterns: "{{ query('fileglob', releases_pattern) | map('regex_replace', '^.*\\.([\\w]+)$', '*.\\1') | list | unique | join(',') }}"
-    excludes: "{{ releases_pattern | basename }}"
+    excludes: "{{ [ releases_pattern | basename ] | union(releases_keepfiles | default([])) }}"
     file_type: link
   register: releases_release_find
 
@@ -15,7 +15,7 @@
     group: "{{ releases_group }}"
     mode: 0644
     state: link
-  loop: "{{ query('fileglob', releases_pattern) | map('basename') | list }}"
+  loop: "{{ query('fileglob', releases_pattern) | map('basename') | list | union(releases_keepfiles | default([])) }}"
   loop_control:
     loop_var: releases_release_symlink
   register: releases_release_files


### PR DESCRIPTION
Sometimes you will have released files that wont
match your releases_pattern. We know support a
list variable of files to keep them from being
removed when you release.