### PR TITLE
Support unpreparing a prepared image

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,12 @@
     - never
     - prepare
 
+- name: Run unprepare tasks # in case the image didn't work
+  import_tasks: unprepare.yml
+  tags:
+   - never
+   - unprepare
+
 - name: Run release tasks
   import_tasks: release.yml
   tags:

--- a/tasks/unprepare.yml
+++ b/tasks/unprepare.yml
@@ -1,0 +1,17 @@
+---
+- name: Remove files in staging area
+  file:
+    path: "{{ releases_path + '/.pool/' + item | basename }}"
+    state: absent
+  loop: "{{ query('fileglob', releases_pattern) }}"
+  loop_control:
+    label: "{{ item | basename }}"
+
+- name: Remove checksums in staging area
+  lineinfile:
+    path: "{{ releases_path + '/.pool/' + item.1 | upper + 'SUMS' }}"
+    regexp: " *{{ item.0 | basename }}$"
+    state: absent
+  loop: "{{ query('fileglob', releases_pattern) | select('contains', '.iso') | list | product(['md5', 'sha1', 'sha256']) | list }}"
+  loop_control:
+    label: "{{ item.1 | upper + ': ' + item.0 | basename }}"


### PR DESCRIPTION
Running the role with tag unprepare will remove the prestaged image and checksum entries from .pool.